### PR TITLE
[bugfix] Corrected behavior of double-click on scrollbar

### DIFF
--- a/src/ToolWindows/KnownMonikersExplorerControl.xaml
+++ b/src/ToolWindows/KnownMonikersExplorerControl.xaml
@@ -1,15 +1,15 @@
 ﻿<UserControl x:Class="KnownMonikersExplorer.ToolWindows.KnownMonikersExplorerControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:KnownMonikersExplorer.ToolWindows"
              xmlns:imaging="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:theming="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Imaging"
              xmlns:platformUI="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
              xmlns:util="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Utilities"
              xmlns:catalog="clr-namespace:Microsoft.VisualStudio.Imaging;assembly=Microsoft.VisualStudio.ImageCatalog"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              local:VsTheme.UseVsTheme="True"
              d:DesignHeight="450" d:DesignWidth="400" UseLayoutRounding="True">
     <Grid>
@@ -22,10 +22,11 @@
 
         <ListView Name="list" Margin="5,0" Grid.Row="1" ItemsSource="{Binding Monikers}"
                   SelectionMode="Single"
-                  ScrollViewer.HorizontalScrollBarVisibility="Disabled" 
+                  ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                   VirtualizingPanel.VirtualizationMode="Recycling"
-                  theming:ImageThemingUtilities.ImageBackgroundColor="{Binding Background, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushToColorConverter}}">
-            
+                  theming:ImageThemingUtilities.ImageBackgroundColor="{Binding Background, RelativeSource={RelativeSource Self}, Converter={StaticResource BrushToColorConverter}}"
+                  MouseDoubleClick="List_MouseDoubleClick">
+
             <ListView.Resources>
                 <Style TargetType="GridViewColumnHeader">
                     <Setter Property="Visibility" Value="Collapsed" />

--- a/src/ToolWindows/KnownMonikersExplorerControl.xaml.cs
+++ b/src/ToolWindows/KnownMonikersExplorerControl.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Media;
 
 namespace KnownMonikersExplorer.ToolWindows
 {
@@ -94,6 +95,28 @@ namespace KnownMonikersExplorer.ToolWindows
         {
             var model = (KnownMonikersViewModel)list.SelectedItem;
             Clipboard.SetText(model.Name);
+        }
+
+        private void List_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            var listViewItem = VisualTreeHelperExtensions.FindAncestor<ListViewItem>((DependencyObject)(e.OriginalSource));
+            if (listViewItem is null)
+                e.Handled = true;
+        }
+    }
+
+    internal static class VisualTreeHelperExtensions
+    {
+        internal static T FindAncestor<T>(DependencyObject dependencyObject)
+            where T : class
+        {
+            DependencyObject target = dependencyObject;
+            do
+            {
+                target = VisualTreeHelper.GetParent(target);
+            }
+            while (target != null && !(target is T));
+            return target as T;
         }
     }
 }


### PR DESCRIPTION
Corrects a bug that crashes Visual Studio if you double-click the scroll bar when no ListItem is selected