### PR TITLE
Allow copying GUID and ID to clipboard

### DIFF
--- a/src/KnownMonikersExplorerShared/ToolWindows/KnownMonikersExplorerControl.xaml
+++ b/src/KnownMonikersExplorerShared/ToolWindows/KnownMonikersExplorerControl.xaml
@@ -52,7 +52,17 @@
                                 <MenuItem Header="Copy Name to Clipboard">
                                     <MenuItem.Style>
                                         <Style TargetType="MenuItem">
-                                            <EventSetter Event="Click" Handler="Copy_Click"/>
+                                            <EventSetter Event="Click" Handler="CopyName_Click"/>
+                                        </Style>
+                                    </MenuItem.Style>
+                                    <MenuItem.Icon>
+                                        <imaging:CrispImage Width="16" Height="16" Moniker="{x:Static catalog:KnownMonikers.Copy}" />
+                                    </MenuItem.Icon>
+                                </MenuItem>
+                                <MenuItem Header="Copy GUID &amp; ID to Clipboard">
+                                    <MenuItem.Style>
+                                        <Style TargetType="MenuItem">
+                                            <EventSetter Event="Click" Handler="CopyGuidAndId_Click"/>
                                         </Style>
                                     </MenuItem.Style>
                                     <MenuItem.Icon>

--- a/src/KnownMonikersExplorerShared/ToolWindows/KnownMonikersExplorerControl.xaml.cs
+++ b/src/KnownMonikersExplorerShared/ToolWindows/KnownMonikersExplorerControl.xaml.cs
@@ -45,7 +45,7 @@ namespace KnownMonikersExplorer.ToolWindows
             }
             else if (e.Key == Key.C && Keyboard.Modifiers == ModifierKeys.Control)
             {
-                Copy_Click(this, new RoutedEventArgs());
+                CopyName_Click(this, new RoutedEventArgs());
             }
         }
 
@@ -89,10 +89,16 @@ namespace KnownMonikersExplorer.ToolWindows
             export.ShowDialog();
         }
 
-        private void Copy_Click(object sender, RoutedEventArgs e)
+        private void CopyName_Click(object sender, RoutedEventArgs e)
         {
             var model = (KnownMonikersViewModel)list.SelectedItem;
             Clipboard.SetText(model.Name);
+        }
+
+        private void CopyGuidAndId_Click(object sender, RoutedEventArgs e)
+        {
+            var model = (KnownMonikersViewModel)list.SelectedItem;
+            Clipboard.SetText($"{model.Moniker.Guid}, {model.Moniker.Id}");
         }
 
         private void List_MouseDoubleClick(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
Fixes #8

![image](https://github.com/madskristensen/KnownMonikersExplorer/assets/350947/71f88bf6-d243-4c40-b94e-d74954150126)

Invoking copies the following to the clipboard:

```
ae27a6b0-e345-4288-96df-5eaf394ee369, 1
```